### PR TITLE
fix: Correct tracking of auto-generated files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ pnpm-debug.log*
 .env
 .next
 .vercel
+tsconfig.tsbuildinfo
+
+# Auto Generated PWA files
+**/public/workbox-*.js
+**/public/sw.js
+**/public/worker-*.js


### PR DESCRIPTION
## Description

I updated the `.gitignore` to exclude files generated when running local builds using `yarn build`.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## Change details

N/A

## Resources

[.gitignore suggestion by next-pwa](https://github.com/shadowwalker/next-pwa/tree/master/examples/custom-worker#recommend-gitignore)