### PR TITLE
fix: Resolve unique key prop error within map function

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,6 @@ function	Index(): ReactElement {
 		})
 	});
 	const	bla = useBalance();
-	console.log(bla);
 	const ethBalancesOf = bla.data;
 	// 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 
@@ -106,24 +105,21 @@ function	Index(): ReactElement {
 							.map((pair: TPair, index: number): ReactElement => {
 								// pair.underlyingAddress
 								if (pair.underlyingAddress === toAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')) {
-									console.log(ethBalancesOf);
 									return (
-										<>
+										<div key={`${pair.underlyingAddress}_${index}`}>
 											<MigrateBox
-												key={`eth_${index}`}
 												pair={pair}
 												// retrieveBalances={retrieveBalances}
 												onForceRerender={(): void => set_nonce(nonce + 1)}
 												balance={ethBalancesOf?.normalized || '0'}
 												rawBalance={ethBalancesOf?.raw || ethers.BigNumber.from(0)} />
 											<MigrateBox
-												key={`${pair.underlyingAddress}_${index}`}
 												pair={pair}
 												// retrieveBalances={retrieveBalances}
 												onForceRerender={(): void => set_nonce(nonce + 1)}
 												balance={balancesOf?.[pair.uToken.address]?.normalized || '0'}
 												rawBalance={balancesOf?.[pair.uToken.address]?.raw || ethers.BigNumber.from(0)} />
-										</>
+										</div>
 									);
 								}
 								return (<MigrateBox


### PR DESCRIPTION
## Description

I converted a `React.Fragment` containing MigrateBox components to a `div` and added a unique key to resolve the error seen below. The MigrateBox components had keys but since they weren't the root element within the map function the given key props weren't being recognized. A `React.Fragment` can't be given properties which is why it had to be converted into a `div`. 

Main goal with this is to keep the console tidy. Extra: removed console logs

<img width="742" alt="unique-key-error" src="https://user-images.githubusercontent.com/95051992/192785455-4ae53e25-9878-444a-ae0b-02428e82bce6.png">


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## Change details

N/A

## Resources

N/A
